### PR TITLE
Update approved refund response.

### DIFF
--- a/official-cornerstone-api.md
+++ b/official-cornerstone-api.md
@@ -518,13 +518,11 @@ Approved Refund
 HTTP/1.1 200 OK
 
 {
-	"approved": [
-		{
-			"refundedTrans": "219677",
-                	"refundRefID": 219749,
-                	"amount": -50
-		}
-	]
+	"approved": {
+		"refundedTrans": "219677",
+		"refundRefID": 219749,
+		"amount": -50
+	}
 }
 ```
 


### PR DESCRIPTION
In my testing, a declined refund does not return an array, but rather a single object.
